### PR TITLE
Tag ec2 snaps with deployment name

### DIFF
--- a/nixops/backends/ec2.py
+++ b/nixops/backends/ec2.py
@@ -478,7 +478,7 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
                 snapshot_tags = {}
                 snapshot_tags.update(defn.tags)
                 snapshot_tags.update(self.get_common_tags())
-                snapshot_tags['Name'] = "{0} - {3} [{1} - {2}]".format(self.depl.description, self.name, device_stored, backup_id)
+                snapshot_tags['Name'] = "{0} - {3} [{1} - {2}]".format(self.depl.name, self.name, device_stored, backup_id)
 
                 self._retry(lambda: self._conn.create_tags([snapshot.id], snapshot_tags))
                 backup[device_stored] = snapshot.id
@@ -1582,3 +1582,4 @@ class EC2State(MachineState, nixops.resources.ec2_common.EC2CommonState):
     def sorted_block_device_mapping(self):
         """In order to preserve nvme devices names volumes should be attached in lexicographic order (ordered by device name)."""
         return sorted(self.block_device_mapping.items())
+


### PR DESCRIPTION
Using deployment name instead of depl description for the backup operation

Would like to add a minor enhancement related to the ec2 snapshot's name taken as part of a backup operation. In fact, currently the network 'description' is being used within the snap name while usually it is not being set or the default one is being used ( Unnamed NixOps network )

https://github.com/NixOS/nixops-aws/blob/master/nixopsaws/backends/ec2.py#L482

As a result, most of our snapshots do not really make sense and we cannot easily filter them in the AWS console.

If we use the deployment name instead we would ensure uniqueness and reliability.